### PR TITLE
Update to clojure.basis

### DIFF
--- a/src/juxt/kick/alpha/providers/figwheel_main.clj
+++ b/src/juxt/kick/alpha/providers/figwheel_main.clj
@@ -20,9 +20,12 @@
 
 (defn lib-dirs
   []
-  (when-let [lib (some-> (System/getProperty "clojure.libfile")
+  (when-let [lib (some-> (or (some->> (System/getProperty "clojure.libfile")
+                                      (format "{:libs %s}"))
+                             (System/getProperty "clojure.basis"))
                          slurp
-                         edn/read-string)]
+                         edn/read-string
+                         :libs)]
     (eduction
       (comp
         (map :paths)
@@ -44,9 +47,12 @@
     classpath-dirs))
 
 (def kick-paths
-  (some-> (System/getProperty "clojure.libfile")
+  (some-> (or (some->> (System/getProperty "clojure.libfile")
+                       (format "{:libs %s}"))
+              (System/getProperty "clojure.basis"))
           slurp
           edn/read-string
+          :libs
           (get 'juxt/kick.alpha)
           :paths
           set))


### PR DESCRIPTION
clj no longer produces a clojure.libfile, and kick needs this to remove
itself from the classpath when using figwheel-main.  Newer versions of
clj instead provide a clojure.basis, which is vaguely the same as the
old basis.

Supports both in order to handle the transition period of updates.